### PR TITLE
fix appveyor badge link

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 # R/`origami` <img src="./hex/origami-sticker.png" align="right" width='125'/>
 
 [![Travis-CI Build Status](https://travis-ci.org/tlverse/origami.svg?branch=master)](https://travis-ci.org/tlverse/origami)
-[![Build status](https://ci.appveyor.com/api/projects/status/i5qwp8cjb4j4x329?svg=true)](https://ci.appveyor.com/project/tlverse/origami)
+[![Build status](https://ci.appveyor.com/api/projects/status/bfe2jd9a065jhql7?svg=true](https://ci.appveyor.com/project/tlverse/origami)
 [![Coverage Status](https://codecov.io/gh/tlverse/origami/branch/master/graph/badge.svg)](https://codecov.io/gh/tlverse/origami)
 [![CRAN](http://www.r-pkg.org/badges/version/origami)](http://www.r-pkg.org/pkg/origami)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/origami)](https://CRAN.R-project.org/package=origami)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 [![Travis-CI Build
 Status](https://travis-ci.org/tlverse/origami.svg?branch=master)](https://travis-ci.org/tlverse/origami)
-[![Build
-status](https://ci.appveyor.com/api/projects/status/i5qwp8cjb4j4x329?svg=true)](https://ci.appveyor.com/project/tlverse/origami)
+[\[Build
+status\](https://ci.appveyor.com/api/projects/status/bfe2jd9a065jhql7?svg=true](https://ci.appveyor.com/project/tlverse/origami)
 [![Coverage
 Status](https://codecov.io/gh/tlverse/origami/branch/master/graph/badge.svg)](https://codecov.io/gh/tlverse/origami)
 [![CRAN](http://www.r-pkg.org/badges/version/origami)](http://www.r-pkg.org/pkg/origami)

--- a/docs/articles/generalizedCV.html
+++ b/docs/articles/generalizedCV.html
@@ -78,7 +78,7 @@
       <h1>Generalized Cross-Validation with Origami</h1>
                         <h4 class="author">Jeremy Coyle &amp; Nima Hejazi</h4>
             
-            <h4 class="date">2019-08-20</h4>
+            <h4 class="date">2019-08-24</h4>
       
       
       <div class="hidden name"><code>generalizedCV.Rmd</code></div>
@@ -181,7 +181,7 @@ empirical process conditions from CV-TMLE step [@Zheng:2010ua].
 <a class="sourceLine" id="cb13-3" data-line-number="3">cvlm_results &lt;-<span class="st"> </span><span class="kw"><a href="../reference/cross_validate.html">cross_validate</a></span>(<span class="dt">cv_fun =</span> cv_lm, <span class="dt">folds =</span> folds, <span class="dt">data =</span> mtcars,</a>
 <a class="sourceLine" id="cb13-4" data-line-number="4">                               <span class="dt">reg_form =</span> <span class="st">"mpg ~ ."</span>)</a>
 <a class="sourceLine" id="cb13-5" data-line-number="5"><span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(cvlm_results<span class="op">$</span>SE)</a></code></pre></div>
-<pre><code>## [1] 13.55564</code></pre>
+<pre><code>## [1] 14.23446</code></pre>
 <p>Having performed 10-fold cross-validation, we quickly notice that our previous estimate of the model error (by resubstitution) was quite optimistic. The honest estimate of the error is several times larger.</p>
 <hr>
 </div>
@@ -244,7 +244,7 @@ Nima: tried some re-wording to clarify; not sure how much this helped.
 <a class="sourceLine" id="cb19-2" data-line-number="2">cvrf_results &lt;-<span class="st"> </span><span class="kw"><a href="../reference/cross_validate.html">cross_validate</a></span>(<span class="dt">cv_fun =</span> cv_rf, <span class="dt">folds =</span> folds, <span class="dt">data =</span> mtcars,</a>
 <a class="sourceLine" id="cb19-3" data-line-number="3">                               <span class="dt">reg_form =</span> <span class="st">"mpg ~ ."</span>)</a>
 <a class="sourceLine" id="cb19-4" data-line-number="4"><span class="kw"><a href="https://rdrr.io/r/base/mean.html">mean</a></span>(cvrf_results<span class="op">$</span>SE)</a></code></pre></div>
-<pre><code>## [1] 5.541277</code></pre>
+<pre><code>## [1] 5.524763</code></pre>
 <p>Using 10-fold cross-validation (the default), we obtain an honest estimate of the prediction error of random forests. From this, we gather that the use of <code>origami</code>’s <code>cross_validate</code> procedure can be generalized to arbitrary esimation techniques, given availability of an appropriate <code>cv_fun</code> function.</p>
 <hr>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
 <div class="page-header"><h1 class="hasAnchor">
 <a href="#rorigami" class="anchor"></a>R/<code>origami</code> <img src="hex/origami-sticker.png" align="right" width="125">
 </h1></div>
-
+<p><a href="https://travis-ci.org/tlverse/origami"><img src="https://travis-ci.org/tlverse/origami.svg?branch=master" alt="Travis-CI Build Status"></a> <a href="https://ci.appveyor.com/project/tlverse/origami">[Build status](https://ci.appveyor.com/api/projects/status/bfe2jd9a065jhql7?svg=true</a> <a href="https://codecov.io/gh/tlverse/origami"><img src="https://codecov.io/gh/tlverse/origami/branch/master/graph/badge.svg" alt="Coverage Status"></a> <a href="http://www.r-pkg.org/pkg/origami"><img src="http://www.r-pkg.org/badges/version/origami" alt="CRAN"></a> <a href="https://CRAN.R-project.org/package=origami"><img src="https://cranlogs.r-pkg.org/badges/origami" alt="CRAN downloads"></a> <a href="http://www.repostatus.org/#active"><img src="http://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active - The project has reached a stable, usable state and is being actively developed."></a> <a href="http://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3-blue.svg" alt="License: GPL v3"></a> <a href="https://doi.org/10.5281/zenodo.1155901"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.1155901.svg" alt="DOI"></a> <a href="https://doi.org/10.21105/joss.00512"><img src="http://joss.theoj.org/papers/10.21105/joss.00512/status.svg" alt="DOI"></a></p>
 <blockquote>
 <p>High-powered framework for cross-validation. Fold your data like it’s paper!</p>
 </blockquote>
@@ -224,21 +224,7 @@
 </ul>
 </div>
 
-      <div class="dev-status">
-<h2>Dev status</h2>
-<ul class="list-unstyled">
-<li><a href="https://travis-ci.org/tlverse/origami"><img src="https://travis-ci.org/tlverse/origami.svg?branch=master" alt="Travis-CI Build Status"></a></li>
-<li><a href="https://ci.appveyor.com/project/tlverse/origami"><img src="https://ci.appveyor.com/api/projects/status/i5qwp8cjb4j4x329?svg=true" alt="Build status"></a></li>
-<li><a href="https://codecov.io/gh/tlverse/origami"><img src="https://codecov.io/gh/tlverse/origami/branch/master/graph/badge.svg" alt="Coverage Status"></a></li>
-<li><a href="http://www.r-pkg.org/pkg/origami"><img src="http://www.r-pkg.org/badges/version/origami" alt="CRAN"></a></li>
-<li><a href="https://CRAN.R-project.org/package=origami"><img src="https://cranlogs.r-pkg.org/badges/origami" alt="CRAN downloads"></a></li>
-<li><a href="http://www.repostatus.org/#active"><img src="http://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active - The project has reached a stable, usable state and is being actively developed."></a></li>
-<li><a href="http://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3-blue.svg" alt="License: GPL v3"></a></li>
-<li><a href="https://doi.org/10.5281/zenodo.1155901"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.1155901.svg" alt="DOI"></a></li>
-<li><a href="https://doi.org/10.21105/joss.00512"><img src="http://joss.theoj.org/papers/10.21105/joss.00512/status.svg" alt="DOI"></a></li>
-</ul>
-</div>
-</div>
+      </div>
 
 </div>
 


### PR DESCRIPTION
The links was outdated. This replaces it with the current version from appveyor.