### PR TITLE
fixed-pooled-ts: extension of fix-pooled-ts

### DIFF
--- a/R/fold_funs.R
+++ b/R/fold_funs.R
@@ -179,6 +179,8 @@ folds_rolling_origin_pooled <- function(n, t, id = NULL, time = NULL,
   }
 
   ids <- unique(dat$id)
+  times <- unique(dat$time)
+  
   message(paste("Processing", length(ids), "samples with", t, "time points."))
 
   # establish rolling origin forecast for time-series cross-validation
@@ -186,28 +188,13 @@ folds_rolling_origin_pooled <- function(n, t, id = NULL, time = NULL,
     t, first_window,
     validation_size, gap, batch
   )
-
-  folds_rolling_origin <- lapply(rolling_origin_skeleton, function(h) {
-    train_indices <- lapply(ids, function(i) {
-      train <- dat[dat$id == i, ]
-      if (is.null(id) & is.null(time)) {
-        train[h$training_set, ]$index
-      } else {
-        train[which(train$time %in% h$training_set), ]$index
-      }
-    })
-    val_indices <- lapply(ids, function(j) {
-      val <- dat[dat$id == j, ]
-      if (is.null(id) & is.null(time)) {
-        val[h$validation_set, ]$index
-      } else {
-        val[which(val$time %in% h$validation_set), ]$index
-      }
-    })
-    make_fold(
-      v = h$v, training_set = unlist(train_indices),
-      validation_set = unlist(val_indices)
-    )
+  fold <- rolling_origin_skeleton[[1]]
+  folds_rolling_origin <- lapply(rolling_origin_skeleton, function(fold) {
+    train_times <- training(times)
+    valid_times <- validation(times)
+    train_idx <- which(dat$time%in%train_times)
+    valid_idx <- which(dat$time%in%valid_times)
+    fold <- make_fold(fold_index(), train_idx, valid_idx)
   })
   return(folds_rolling_origin)
 }

--- a/tests/testthat/test-overall_timeseries.R
+++ b/tests/testthat/test-overall_timeseries.R
@@ -85,16 +85,21 @@ if (require("forecast")) {
 
   #############################################################################
   # Test multiple time-series functionality
-  test_data <- data.table(melt(data.table(AirPassengers),
-    measure.vars = "AirPassengers"
-  ))
-
+  n_id <- 100
+  test_data <- data.table(id=seq_len(n_id))
+  test_data <- test_data[,list(t=seq_len(floor(runif(1)*50))),by=list(id)]
+  test_data[,X:=rnorm(.N)]
+  
+  
   ### Independent sample example
   folds <- make_folds(test_data,
     fold_fun = folds_rolling_origin_pooled,
-    t = 12, first_window = 4,
+    id = test_data$id,
+    t = max(test_data$t),
+    time = test_data$t, first_window = 4,
     validation_size = 4, gap = 0, batch = 2
   )
+
   test_that("Size of the first fold of rolling origin pooled CV", {
     expect_equal(length(folds[[1]]$training_set), 48, tolerance = 0.01)
   })


### PR DESCRIPTION
Accidentally created a new name for the functionality that speeds up pooled timeseries cross-validation. This branch "fixed-pooled-ts" extends the branch "fix-pooled-ts".